### PR TITLE
:tada: graphqlでpost, put をできるようした

### DIFF
--- a/app/graphql/mutations/create_task.rb
+++ b/app/graphql/mutations/create_task.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Mutations
+  class CreateTask < BaseMutation
+    graphql_name 'CreateTask'
+
+    field :task, Types::TaskType, null: true
+    field :result, Boolean, null: true
+
+    argument :title, String, required: false
+    argument :description, String, required: false
+
+    def resolve(**args)
+      task = Task.create(
+        title: args[:title],
+        description: args[:description],
+        completed: false
+      )
+      {
+        task: task,
+        result: task.errors.blank?
+      }
+    end
+  end
+end

--- a/app/graphql/mutations/delete_task.rb
+++ b/app/graphql/mutations/delete_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Mutations
+  class DeleteTask < BaseMutation
+    graphql_name 'DeleteTask'
+
+    field :task, Types::TaskType, null: true
+    field :result, Boolean, null: true
+
+    argument :id, ID, required: true
+
+    def resolve(**args)
+      task = Task.find(args[:id])
+      task.destroy
+      {
+        task: task
+      }
+    end
+  end
+end

--- a/app/graphql/mutations/update_task.rb
+++ b/app/graphql/mutations/update_task.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Mutations
+  class UpdateTask < BaseMutation
+    graphql_name 'UpdateTask'
+
+    field :task, Types::TaskType, null: true
+    field :result, Boolean, null: true
+
+    argument :id, ID, required: true
+    argument :completed, Boolean, required: true
+
+    def resolve(**args)
+      task = Task.find(args[:id])
+      task.update(completed: args[:completed])
+      {
+        task: task,
+        result: task.errors.blank?
+      }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,6 +2,9 @@
 
 module Types
   class MutationType < Types::BaseObject
+    field :delete_task, mutation: Mutations::DeleteTask
+    field :update_task, mutation: Mutations::UpdateTask
+    field :create_task, mutation: Mutations::CreateTask
     # TODO: remove me
     field :test_field, String, null: false,
       description: "An example field added by the generator"

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'localhost:8080'
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end


### PR DESCRIPTION
closes:
ref:

# 目的
graphql を実装し値の作成、更新、削除を実現する

# やったこと
- GraphQL Mutationを定義 
  - create
  - update
  - dalete
- CORS設定を追加

# 注記
新規作成(mutation)
```
mutation {
  createTask(
    input: {
      title: "new task"
      description: "This is a new task."
    }
  ) {
    task {
      id
      title
      description
      completed
    }
    result
  }
}
```

更新(mutation)
```
mutation {
  updateTask(
    input: {
      id: 11
      completed: true
    }
  ) {
    task {
      id
      title
      description
      completed
    }
    result
  }
}
```

削除(mutation)
```
mutation {
  deleteTask(
    input: {
      id: 11
    }
  ) {
    task{
      id
    }
  }
}
```